### PR TITLE
feat: add `.len()` for getting current length of the builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "capacity_builder"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "divan",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "capacity_builder"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/dsherret/capacity_builder"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ impl<'a> StringBuilder<'a> {
 
   /// Gets the current length of the builder.
   ///
-  /// On the first pass this will be the current capacity and
+  /// On the first pass this will be the current calculated capacity and
   /// on the second pass it will be the current length of the string.
   #[allow(clippy::len_without_is_empty)]
   pub fn len(&self) -> usize {
@@ -297,7 +297,7 @@ impl<'a> BytesBuilder<'a> {
 
   /// Gets the current length of the builder.
   ///
-  /// On the first pass this will be the current capacity and
+  /// On the first pass this will be the current calculated capacity and
   /// on the second pass it will be the current length of the bytes.
   #[allow(clippy::len_without_is_empty)]
   pub fn len(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,15 @@ impl<'a> StringBuilder<'a> {
     Ok(builder.text.unwrap())
   }
 
+  /// Gets the current length of the builder.
+  ///
+  /// On the first pass this will be the current capacity and
+  /// on the second pass it will be the current length of the string.
+  #[allow(clippy::len_without_is_empty)]
+  pub fn len(&self) -> usize {
+    self.text.as_ref().map(|t| t.len()).unwrap_or(self.capacity)
+  }
+
   #[inline(always)]
   pub fn append(&mut self, value: impl StringAppendable + 'a) {
     match &mut self.text {
@@ -284,6 +293,19 @@ impl<'a> BytesBuilder<'a> {
     build(&mut builder);
     debug_assert_eq!(builder.capacity, builder.bytes.as_ref().unwrap().len());
     Ok(builder.bytes.unwrap())
+  }
+
+  /// Gets the current length of the builder.
+  ///
+  /// On the first pass this will be the current capacity and
+  /// on the second pass it will be the current length of the bytes.
+  #[allow(clippy::len_without_is_empty)]
+  pub fn len(&self) -> usize {
+    self
+      .bytes
+      .as_ref()
+      .map(|t| t.len())
+      .unwrap_or(self.capacity)
   }
 
   #[inline(always)]
@@ -337,8 +359,11 @@ mod test {
   fn bytes_builder() {
     let bytes = BytesBuilder::build(|builder| {
       builder.append("Hello, ");
+      assert_eq!(builder.len(), 7);
       builder.append("world!");
+      assert_eq!(builder.len(), 13);
       builder.append("testing ");
+      assert_eq!(builder.len(), 21);
     })
     .unwrap();
     assert_eq!(String::from_utf8(bytes).unwrap(), "Hello, world!testing ");


### PR DESCRIPTION
This returns the current calculated capacity on the first run and the current length on the second.